### PR TITLE
Invoice item relationships

### DIFF
--- a/app/controllers/api/v1/invoice_items/invoices_controller.rb
+++ b/app/controllers/api/v1/invoice_items/invoices_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::InvoiceItems::InvoicesController < ApplicationController
+  def show
+    render json: InvoiceItem.find(params[:id]).invoice
+  end
+end

--- a/app/controllers/api/v1/invoice_items/items_controller.rb
+++ b/app/controllers/api/v1/invoice_items/items_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::InvoiceItems::ItemsController < ApplicationController
+  def show
+    render json: InvoiceItem.find(params[:id]).item
+  end
+end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,2 +1,4 @@
 class InvoiceItem < ApplicationRecord
+  belongs_to :invoice
+  belongs_to :item
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,3 @@
+class ItemSerializer < ActiveModel::Serializer
+  attributes :id, :name, :description, :merchant_id, :unit_price
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,10 @@ Rails.application.routes.draw do
         get '/:id/invoice_items', to: 'invoice_items#index'
       end
 
+      namespace :invoice_items do
+        get '/:id/invoice', to: 'invoices#show'
+      end
+
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
 
       namespace :invoice_items do
         get '/:id/invoice', to: 'invoices#show'
+        get '/:id/item', to: 'items#show'
       end
 
     end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe 'Invoice Item' do
+  context 'relationships' do
+    it 'belongs to an invoice and an item' do
+      invoice_item = create(:invoice_item)
+      expect(invoice_item).to respond_to(:invoice)
+      expect(invoice_item).to respond_to(:item)
+    end
+  end
+end

--- a/spec/requests/api/v1/invoice_items/relationships_spec.rb
+++ b/spec/requests/api/v1/invoice_items/relationships_spec.rb
@@ -13,4 +13,13 @@ describe 'Invoice Items API relationships' do
     invoice = JSON.parse(response.body)
     expect(invoice['id']).to eq(@invoice_item.invoice_id)
   end
+
+  it 'sends the associated item for a given invoice_item' do
+    get "/api/v1/invoice_items/#{@invoice_item.id}/item"
+
+    expect(response).to be_success
+
+    item = JSON.parse(response.body)
+    expect(item['id']).to eq(@invoice_item.item_id)
+  end
 end

--- a/spec/requests/api/v1/invoice_items/relationships_spec.rb
+++ b/spec/requests/api/v1/invoice_items/relationships_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe 'Invoice Items API relationships' do
+  before(:each) do
+    @invoice_item = create(:invoice_item)
+  end
+
+  it 'sends the associated invoice for a given invoice_item' do
+    get "/api/v1/invoice_items/#{@invoice_item.id}/invoice"
+
+    expect(response).to be_success
+
+    invoice = JSON.parse(response.body)
+    expect(invoice['id']).to eq(@invoice_item.invoice_id)
+  end
+end

--- a/spec/support/factories/invoice_item.rb
+++ b/spec/support/factories/invoice_item.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :invoice_item do
+    invoice
+    item
+    quantity 4
+    unit_price 2500
+    created_at Time.now
+    updated_at Time.now
+  end
+end


### PR DESCRIPTION
## Changes Proposed:
Invoice Item Relationships: 
* GET /api/v1/invoice_items/:id/invoice returns the associated invoice
* GET /api/v1/invoice_items/:id/item returns the associated item

## Fixes:


## Checklist:
* Tested on RSPEC? ✔️
* All test passing? ✔️
* Passing Spec Harness? ✔️

## Mentions:
