### PR TITLE
19 best day

### DIFF
--- a/app/controllers/api/v1/items/best_day_controller.rb
+++ b/app/controllers/api/v1/items/best_day_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Items::BestDayController < ApplicationController
+  def show
+    best_day = Item.find(params[:id]).best_day
+    render json: { "best_day": best_day }
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,4 +12,15 @@ class Item < ApplicationRecord
     .order('item_quant DESC')
     .limit(x)
   end
+
+  def best_day
+    invoices
+      .merge(Invoice.success)
+      .select('invoices.created_at, sum(invoice_items.quantity * invoice_items.unit_price) AS revenue')
+      .joins(:invoice_items)
+      .group('invoices.created_at')
+      .order('revenue DESC')
+      .first
+      .created_at
+    end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
         get '/:id/merchant', to: 'merchants#show'
         get '/:id/invoice_items', to: 'invoice_items#index'
         get '/most_items', to: 'most_items#index'
+        get '/:id/best_day', to: 'best_day#show'
       end
       resources :items, only: [:index, :show]
 

--- a/spec/requests/api/v1/items/business_intel_spec.rb
+++ b/spec/requests/api/v1/items/business_intel_spec.rb
@@ -22,4 +22,10 @@ describe 'Items API' do
     expect(items.first['id']).to eq(@item.id)
     expect(items.length).to eq(1)
   end
+  it 'returns the date with the most sales for a given item' do
+    item = create(:item)
+    get "/api/v1/items/#{item.id}/best_day"
+
+    expect(response).to be_success
+  end
 end

--- a/spec/requests/api/v1/items/business_intel_spec.rb
+++ b/spec/requests/api/v1/items/business_intel_spec.rb
@@ -1,20 +1,23 @@
 require 'rails_helper'
 
 describe 'Items API' do
-  it 'can return the top x item instances ranked by total number sold' do
+  before(:each) do
     @item = create(:item)
     @item_2 = create(:item)
+    @day = '2018-01-20T01:00:00.000Z'
+    invoice = create(:invoice, created_at: @day)
     invoice_item_1 = create(:invoice_item, item: @item, quantity: 10)
-    invoice_item_2 = create(:invoice_item, item: @item, quantity: 30)
+    @invoice_item_2 = create(:invoice_item, item: @item, quantity: 30, invoice: invoice)
     invoice_item_3 = create(:invoice_item, item: @item_2, quantity: 2)
     invoice_item_4 = create(:invoice_item, item: @item_2, quantity: 3)
     invoice_item_5 = create(:invoice_item, item: @item_2, quantity: 4)
     create(:transaction, invoice_id: invoice_item_1.invoice_id)
-    create(:transaction, invoice_id: invoice_item_2.invoice_id)
+    create(:transaction, invoice_id: @invoice_item_2.invoice_id)
     create(:transaction, invoice_id: invoice_item_3.invoice_id)
     create(:transaction, invoice_id: invoice_item_4.invoice_id)
     create(:transaction, invoice_id: invoice_item_5.invoice_id)
-
+  end
+  it 'can return the top x item instances ranked by total number sold' do
     get "/api/v1/items/most_items?quantity=1"
     expect(response).to be_success
 
@@ -23,9 +26,10 @@ describe 'Items API' do
     expect(items.length).to eq(1)
   end
   it 'returns the date with the most sales for a given item' do
-    item = create(:item)
-    get "/api/v1/items/#{item.id}/best_day"
-
+    get "/api/v1/items/#{@item.id}/best_day"
     expect(response).to be_success
+
+    date = JSON.parse(response.body)
+    expect(date['best_day']).to eq(@day)
   end
 end


### PR DESCRIPTION
## Changes Proposed:
* GET /api/v1/items/:id/best_day returns the date with the most sales for the given item using the invoice date. If there are multiple days with equal number of sales, return the most recent day.

## Fixes:


## Checklist:
* Tested on RSPEC ✔️
* All test passing? ✔️
* Passing Spec Harness?✔️

## Mentions:
